### PR TITLE
Added option to set ylim in plotChromBins

### DIFF
--- a/R/chrom-plots.R
+++ b/R/chrom-plots.R
@@ -196,6 +196,7 @@ calcChromBinsRef = function(query, refAssembly, binCount=10000) {
 #' @param binCount Number of bins (should match the call to
 #'     \code{genomicDistribution})
 #' @param plotTitle Title for plot.
+#' @param ylim Limit of y-axes. Default "max" sets limit to N of biggest bin.
 #' @return A ggplot object showing the distribution of the query 
 #'     regions over bins of
 #' the reference genome.
@@ -206,7 +207,7 @@ calcChromBinsRef = function(query, refAssembly, binCount=10000) {
 #' ChromBins = plotChromBins(agg)
 #' 
 plotChromBins = function(genomeAggregate, binCount=10000, 
-                           plotTitle="Distribution over chromosomes") {
+                           plotTitle="Distribution over chromosomes", ylim="max") {
     .validateInputs(list(genomeAggregate=c("data.table","data.frame")))
     
     if ("name" %in% names(genomeAggregate)){
@@ -231,8 +232,13 @@ plotChromBins = function(genomeAggregate, binCount=10000,
         theme(panel.spacing=unit(0, "lines")) + # Reduce whitespace
         theme(strip.text.y=element_text(size=12, angle=0)) + # Rotate labels
         geom_hline(yintercept=0, color="#EEEEEE") + # Light chrom lines
-        scale_y_continuous(breaks=c(max(genomeAggregate$N)), 
-                            limits=c(0, max(genomeAggregate$N))) +
+        {if (ylim == "max") {
+            scale_y_continuous(breaks = c(max(genomeAggregate$N)),
+                               limits = c(0, max(genomeAggregate$N)))
+        } else {
+            scale_y_continuous(breaks = ylim,
+                               limits = c(0, ylim))
+        }} +
     scale_x_continuous(breaks=c(0, binCount), labels=c("Start", "End")) +
     theme(plot.title=element_text(hjust=0.5)) + # Center title
     ggtitle(plotTitle) +


### PR DESCRIPTION
- even one extreme bin size makes the plotChromBins output less usable
  - e.g. if most bins N ~10-100 and one is 8000 everything is scaled for this one bar (ran into this twice now in my work)
- instead of having to manually remove data one can simply set the ylim manually using the new ylim option